### PR TITLE
Quickstart example wraps find_past boolean in quotes

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ pip install funda-scraper
 ```
 from funda_scraper import FundaScraper
 
-scraper = FundaScraper(area="amsterdam", want_to="rent", find_past="False")
+scraper = FundaScraper(area="amsterdam", want_to="rent", find_past=False)
 df = scraper.run()
 df.head()
 ```


### PR DESCRIPTION
Removed quotes from boolean, for pasteability