### PR TITLE
Increased page limit and improved postal code accuracy from PC4 to PC6

### DIFF
--- a/funda_scraper/preprocess.py
+++ b/funda_scraper/preprocess.py
@@ -149,7 +149,7 @@ def preprocess_data(df: pd.DataFrame, is_past: bool) -> pd.DataFrame:
     df["price_m2"] = round(df.price / df.living_area, 1)
 
     # Location
-    df["zip"] = df["zip_code"].apply(lambda x: x[:4])
+    df["zip"] = df["zip_code"].apply(lambda x: x[:7])
 
     # House layout
     df["room"] = df["num_of_rooms"].apply(find_n_room)

--- a/funda_scraper/scrape.py
+++ b/funda_scraper/scrape.py
@@ -28,7 +28,7 @@ class FundaScraper:
         self.area = area.lower().replace(" ", "-") if isinstance(area, str) else area
         self.want_to = want_to
         self.find_past = find_past
-        self.n_pages = min(max(n_pages, 1), 999)
+        self.n_pages = min(max(n_pages, 1), 10000)
         self.links: List[str] = []
         self.raw_df = pd.DataFrame()
         self.clean_df = pd.DataFrame()


### PR DESCRIPTION
I encountered an issue with the hard limit of 999 pages in the `scrape.py` file. To address this, I have modified the code to set the limit to max 10k pages.

In addition, I noticed that the code only used PC4 for zip code information, even though PC6 information is available. To make use of this additional information, I have modified the `preprocess.py` file to allow saving 1234 AB (PC6) as a zip code versus just 1234 (PC4).

These changes will allow users to perform searches across multiple cities and provide more detailed location information. Thank you for considering my pull request.