### PR TITLE
Improvement: allow filtering the query on property type

### DIFF
--- a/funda_scraper/scrape.py
+++ b/funda_scraper/scrape.py
@@ -31,9 +31,11 @@ class FundaScraper(object):
         find_past: bool = False,
         min_price: Optional[int] = None,
         max_price: Optional[int] = None,
+        property_type: Optional[str] = None,
     ):
         # Init attributes
         self.area = area.lower().replace(" ", "-")
+        self.property_type = property_type
         self.want_to = want_to
         self.find_past = find_past
         self.page_start = max(page_start, 1)
@@ -90,6 +92,7 @@ class FundaScraper(object):
     def reset(
         self,
         area: Optional[str] = None,
+        property_type: Optional[str] = None,
         want_to: Optional[str] = None,
         page_start: Optional[int] = None,
         n_pages: Optional[int] = None,
@@ -100,6 +103,8 @@ class FundaScraper(object):
         """Overwrite or initialise the searching scope."""
         if area is not None:
             self.area = area
+        if property_type is not None:
+            self.property_type = property_type
         if want_to is not None:
             self.want_to = want_to
         if page_start is not None:
@@ -142,7 +147,13 @@ class FundaScraper(object):
 
     def _build_main_query_url(self) -> str:
         query = "koop" if self.to_buy else "huur"
-        main_url = f"{self.base_url}/zoeken/{query}?selected_area=%22{self.area}%22"
+
+        main_url = f"{self.base_url}/zoeken/{query}?selected_area=%5B%22{self.area}%22%5D"
+
+        if self.property_type:
+            property_types = self.property_type.split(',')
+            formatted_property_types = ['%22' + prop_type + '%22' for prop_type in property_types]
+            main_url += f"&object_type=%5B{','.join(formatted_property_types)}%5D"
 
         if self.find_past:
             main_url = f"{main_url}&availability=%22unavailable%22"

--- a/tests/test_scrape.py
+++ b/tests/test_scrape.py
@@ -46,3 +46,39 @@ class TestFundaScraper(object):
         df = preprocess_data(df, is_past=True)
         assert df.shape[0] > 12
         assert df.shape[1] == 17
+
+    def test_buy_house(self):
+        scraper = FundaScraper(area="amsterdam", property_type="house", want_to="buy", find_past=False, page_start=1, n_pages=1)
+        df = scraper.run(raw_data=True)
+        assert len(scraper.links) == 15
+        assert df.shape == (15, 27)
+        assert df['city'].unique()[0] == 'amsterdam'
+
+        df = preprocess_data(df, is_past=False)
+        assert df.shape[0] > 12
+        assert df.shape[1] == 17
+        assert df['house_type'].unique()[0] == 'huis'
+
+    def test_buy_apartment(self):
+        scraper = FundaScraper(area="amsterdam", property_type="apartment", want_to="buy", find_past=False, page_start=1, n_pages=1)
+        df = scraper.run(raw_data=True)
+        assert len(scraper.links) == 15
+        assert df.shape == (15, 27)
+        assert df['city'].unique()[0] == 'amsterdam'
+
+        df = preprocess_data(df, is_past=False)
+        assert df.shape[0] > 12
+        assert df.shape[1] == 17
+        assert df['house_type'].unique()[0] == 'appartement'
+
+    def test_buy_mixed(self):
+        scraper = FundaScraper(area="amsterdam", property_type="apartment,house", want_to="buy", find_past=False, page_start=1, n_pages=1)
+        df = scraper.run(raw_data=True)
+        assert len(scraper.links) == 15
+        assert df.shape == (15, 27)
+        assert df['city'].unique()[0] == 'amsterdam'
+
+        df = preprocess_data(df, is_past=False)
+        assert df.shape[0] > 12
+        assert df.shape[1] == 17
+        assert set(df['house_type'].unique()) == set(["appartement", "huis"])


### PR DESCRIPTION
This solves https://github.com/whchien/funda-scraper/issues/27.

It is now possible to filter a query based on property type (only `apartment` and `house` supported at the moment).

For example:
```python
# only query for houses
scraper = FundaScraper(
          area="amsterdam, 
          property_type="house",
          want_to="buy", 
          max_price="450000"

# only query for apartments
scraper = FundaScraper(
          area="amsterdam, 
          property_type="apartment",
          want_to="buy", 
          max_price="450000"
)
```