### PR TITLE
Change type bool args to store_true action

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ pip install funda-scraper
 git clone https://github.com/whchien/funda-scraper.git
 cd funda-scraper
 export PYTHONPATH=${PWD}
-python funda_scraper/scrape.py --area amsterdam --want_to rent --find_past False --page_start 1 --n_pages 3
+python funda_scraper/scrape.py --area amsterdam --want_to rent --page_start 1 --n_pages 3 --save
 ```
 
 ## Quickstart 

--- a/funda_scraper/scrape.py
+++ b/funda_scraper/scrape.py
@@ -346,9 +346,8 @@ if __name__ == "__main__":
     )
     parser.add_argument(
         "--find_past",
-        type=bool,
+        action="store_true",
         help="Indicate whether you want to use hisotrical data or not",
-        default=False,
     )
     parser.add_argument(
         "--page_start", type=int, help="Specify which page to start scraping", default=1
@@ -370,15 +369,13 @@ if __name__ == "__main__":
     )
     parser.add_argument(
         "--raw_data",
-        type=bool,
+        action="store_true",
         help="Indicate whether you want the raw scraping result or preprocessed one",
-        default=False,
     )
     parser.add_argument(
         "--save",
-        type=bool,
+        action="store_true",
         help="Indicate whether you want to save the data or not",
-        default=True,
     )
 
     args = parser.parse_args()

--- a/funda_scraper/scrape.py
+++ b/funda_scraper/scrape.py
@@ -343,11 +343,12 @@ if __name__ == "__main__":
         type=str,
         help="Specify you want to 'rent' or 'buy'",
         default="rent",
+        choices=["rent", "buy"],
     )
     parser.add_argument(
         "--find_past",
         action="store_true",
-        help="Indicate whether you want to use hisotrical data or not",
+        help="Indicate whether you want to use historical data",
     )
     parser.add_argument(
         "--page_start", type=int, help="Specify which page to start scraping", default=1
@@ -370,12 +371,12 @@ if __name__ == "__main__":
     parser.add_argument(
         "--raw_data",
         action="store_true",
-        help="Indicate whether you want the raw scraping result or preprocessed one",
+        help="Indicate whether you want the raw scraping result",
     )
     parser.add_argument(
         "--save",
         action="store_true",
-        help="Indicate whether you want to save the data or not",
+        help="Indicate whether you want to save the data",
     )
 
     args = parser.parse_args()


### PR DESCRIPTION
Hi @whchien, thanks for building this scraper! I was using this recently from the CLI and I noticed that some args are not correctly parsed. For example, running the command from the README:

```
❯ python funda_scraper/scrape.py --area amsterdam --want_to rent --find_past False --page_start 1 --n_pages 3 --raw_data True
```

When printing `args.find_past`, this evaluates to True meaning that it unintentionally uses past data even though I expected recent data. 

This is because some args are parsed as `type=bool`, which unfortunately often leads to a different behavior than expected. "False" is interpreted as string and that evaluates True in Python. On the other hand, inputs like '' and 0 will evaluate as False. The same problem occurs with the `--raw_data` and `--save` arguments.

One way to avoid this problem is to use `action=store_true` instead. I have made these changes along with a few small quality-of-life improvements.
