### PR TITLE
fix: fix size value

### DIFF
--- a/funda_scraper/config/config.yaml
+++ b/funda_scraper/config/config.yaml
@@ -36,7 +36,7 @@ css_selector:
   descrip: ".object-description-body"
   listed_since: ".fd-align-items-center:nth-child(6) span"
   zip_code: ".object-header__subtitle"
-  size: ".fd-m-right-xl--bp-m .fd-text--nowrap"
+  size: ".object-kenmerken-list:nth-child(8) .fd-align-items-center:nth-child(5) span"
   year: ".fd-align-items-center~ .fd-align-items-center .fd-m-right-xs"
   living_area: ".object-kenmerken-list:nth-child(8) .fd-align-items-center:nth-child(2) span"
   kind_of_house: ".object-kenmerken-list:nth-child(5) .fd-align-items-center:nth-child(2) span"


### PR DESCRIPTION
Fixes size value. Currently, size returns the same as living_area. This should do the trick:

<img width="290" alt="image" src="https://github.com/whchien/funda-scraper/assets/13242848/43f59732-ca6a-4802-9b32-2ef6d2b8b8f0">

This gets the "size" value from here:

<img width="453" alt="image" src="https://github.com/whchien/funda-scraper/assets/13242848/c58acd2b-236e-45f5-8c2e-b312ab613405">
